### PR TITLE
Improve event bus contract semantics

### DIFF
--- a/src/Context/Video/Module/Notification/Domain/Notification.php
+++ b/src/Context/Video/Module/Notification/Domain/Notification.php
@@ -27,7 +27,7 @@ final class Notification extends AggregateRoot
     {
         $notification = new self($id, $text, $type, false);
 
-        $notification->raise(
+        $notification->record(
             new NotificationCreatedDomainEvent(
                 $id->value(),
                 [

--- a/src/Context/Video/Module/Video/Domain/Video.php
+++ b/src/Context/Video/Module/Video/Domain/Video.php
@@ -24,7 +24,7 @@ final class Video extends AggregateRoot
     {
         $video = new self($id, $title, $url, $courseId);
 
-        $video->raise(
+        $video->record(
             new VideoCreatedDomainEvent(
                 $id,
                 [

--- a/src/Context/Video/Module/VideoComment/Domain/VideoComment.php
+++ b/src/Context/Video/Module/VideoComment/Domain/VideoComment.php
@@ -21,11 +21,11 @@ final class VideoComment extends AggregateRoot
         $this->content = $content;
     }
 
-    public static function publish(VideoCommentId $id, VideoId $videoId, VideoCommentContent $content)
+    public static function publish(VideoCommentId $id, VideoId $videoId, VideoCommentContent $content): VideoComment
     {
         $comment = new self($id, $videoId, $content);
 
-        $comment->raise(
+        $comment->record(
             new VideoCommentPublishedDomainEvent(
                 $id->value(),
                 [

--- a/src/Context/Video/Module/VideoHighlight/Domain/VideoHighlight.php
+++ b/src/Context/Video/Module/VideoHighlight/Domain/VideoHighlight.php
@@ -22,7 +22,7 @@ final class VideoHighlight extends AggregateRoot
     {
         $videoHighlight = new self($id, $interval, $message);
 
-        $videoHighlight->raise(
+        $videoHighlight->record(
             new VideoHighlightCreatedDomainEvent(
                 $id->value(),
                 [

--- a/src/Infrastructure/Monolog/Formatter/LogstashFormatter.php
+++ b/src/Infrastructure/Monolog/Formatter/LogstashFormatter.php
@@ -25,7 +25,7 @@ class LogstashFormatter extends NormalizerFormatter
             '@timestamp' => $record['datetime'],
             '@version'   => 1,
             'host'       => gethostname(),
-            'tags'       => ['arya', $record['channel']],
+            'tags'       => ['codelytv', $record['channel']],
             'message'    => $record['message'],
             'severity'   => $record['level_name'],
         ];

--- a/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/DomainEventPublisherCompilerPass.php
+++ b/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/DomainEventPublisherCompilerPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CodelyTv\Infrastructure\Symfony\Bundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -40,7 +42,7 @@ class DomainEventPublisherCompilerPass implements CompilerPassInterface
         $events = $subscriberClass::subscribedTo();
 
         foreach ($events as $eventClass) {
-            $publisher->addMethodCall('register', [$eventClass, new Reference($subscriberServiceId)]);
+            $publisher->addMethodCall('subscribe', [$eventClass, new Reference($subscriberServiceId)]);
         }
     }
 }

--- a/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/DomainEventSubscribersConfigurationCompilerPass.php
+++ b/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/DomainEventSubscribersConfigurationCompilerPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CodelyTv\Infrastructure\Symfony\Bundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/TransactionalWrapper.php
+++ b/src/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/TransactionalWrapper.php
@@ -41,7 +41,7 @@ final class TransactionalWrapper
             throw new WrongTransaction($exception);
         }
 
-        $this->publisher->flush();
+        $this->publisher->publishRecorded();
 
         return $result;
     }

--- a/src/Shared/Domain/Bus/Event/DomainEventPublisher.php
+++ b/src/Shared/Domain/Bus/Event/DomainEventPublisher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CodelyTv\Shared\Domain\Bus\Event;
 
 use RuntimeException;
@@ -7,36 +9,24 @@ use RuntimeException;
 interface DomainEventPublisher
 {
     /**
+     * Subscribes a $subscriber function to an specific $eventClass
+     *
      * @throws RuntimeException
-     *
-     * @return void
      */
-    public function register($eventClass, callable $subscriber);
+    public function subscribe(string $eventClass, callable $subscriber): void;
 
     /**
-     * Raises events to be published afterwards
-     *
-     * @param DomainEvent[] $events
-     *
-     * @return void
+     * Records events to be published afterwards using the publishRecorded method
      */
-    public function raise(array $domainEvents);
+    public function record(array $domainEvents): void;
 
     /**
-     * Send events to process
-     *
-     * @param DomainEvent[] $events
-     *
-     * @return void
+     * Publishes previously recorded events
      */
-    public function flush();
+    public function publishRecorded(): void;
 
     /**
-     * Raises events to be published afterwards (with flush command)
-     *
-     * @param DomainEvent[] $events
-     *
-     * @return void
+     * Immediately publishes the received events
      */
     public function publish(array $domainEvents);
 }

--- a/src/Tests/Infrastructure/Bus/Event/DomainEventPublisherSyncTest.php
+++ b/src/Tests/Infrastructure/Bus/Event/DomainEventPublisherSyncTest.php
@@ -24,7 +24,7 @@ final class DomainEventPublisherSyncTest extends UnitTestCase
     /** @test */
     public function it_should_publish_and_handle_one_event()
     {
-        $this->publisher->register(get_class($this->domainEvent()), $this->subscriber());
+        $this->publisher->subscribe(get_class($this->domainEvent()), $this->subscriber());
 
         $this->subscriberShouldBeCalled();
 
@@ -34,8 +34,8 @@ final class DomainEventPublisherSyncTest extends UnitTestCase
     /** @test */
     public function it_should_be_able_to_handle_more_than_one_domain_event()
     {
-        $this->publisher->register(get_class($this->domainEvent()), $this->subscriber());
-        $this->publisher->register(get_class($this->anotherDomainEvent()), $this->subscriber());
+        $this->publisher->subscribe(get_class($this->domainEvent()), $this->subscriber());
+        $this->publisher->subscribe(get_class($this->anotherDomainEvent()), $this->subscriber());
 
         $this->subscriberShouldBeCalled();
         $this->subscriberShouldBeCalledWithTheOtherEvent();

--- a/src/Types/Aggregate/AggregateRoot.php
+++ b/src/Types/Aggregate/AggregateRoot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CodelyTv\Types\Aggregate;
 
 use CodelyTv\Shared\Domain\Bus\Event\DomainEvent;
@@ -8,7 +10,7 @@ abstract class AggregateRoot
 {
     private $domainEvents = [];
 
-    final public function pullDomainEvents()
+    final public function pullDomainEvents(): array
     {
         $domainEvents       = $this->domainEvents;
         $this->domainEvents = [];
@@ -16,7 +18,7 @@ abstract class AggregateRoot
         return $domainEvents;
     }
 
-    final protected function raise(DomainEvent $domainEvent)
+    final protected function record(DomainEvent $domainEvent): void
     {
         $this->domainEvents[] = $domainEvent;
     }


### PR DESCRIPTION
Changes:
* Replace `raise` for `record`: In this method we're not raising/publishing any domain event to the public. We're just recording/storing it in order to be published afterwards.
* Replace `register` for `subscribe`: When we talk about domain events, we always talk in terms of publisher/subscribers. It would make sense to limit the domain events context semantics to these terms in order to avoid adding more friction due to using different terms to reference the same concepts
* Replace `flush` for `publishRecorded`: Due to the previous 2 changes, it makes sense to be more explicit in our API and maintain the same terms. Furthermore, this way we maintain the consistency with the other `publish` method.